### PR TITLE
Add BuildInfo support for build targets

### DIFF
--- a/go.go
+++ b/go.go
@@ -24,6 +24,13 @@ const (
 	ReportsDir = TargetDir + "reports/"
 )
 
+// BuildInfo contains relevant information about produced binary.
+type BuildInfo struct {
+	BinPath string
+	GOOS    string
+	GOARCH  string
+}
+
 // Go is shorthand for go executable provided by system.
 func Go(ctx context.Context, args ...string) error {
 	return GoWith(ctx, nil, args...)
@@ -35,7 +42,7 @@ func GoWith(ctx context.Context, env map[string]string, args ...string) error {
 	return sh.RunWithV(env, "go", args...)
 }
 
-// Targets returns list of main pkgs under utils.CmdDir.
+// Targets returns list of main pkgs under CmdDir.
 func Targets(ctx context.Context) ([]string, error) {
 	entries, err := os.ReadDir(CmdDir)
 	if err != nil {
@@ -67,34 +74,61 @@ func BuildAll(ctx context.Context) error {
 
 // Build binary using settings from system env.
 func Build(ctx context.Context, name string) error {
+	_, err := BuildWithInfo(ctx, name)
+	return err
+}
+
+// BuildWithInfo builds binary using settings from system env and returns additional build information.
+func BuildWithInfo(ctx context.Context, name string) (BuildInfo, error) {
 	goos, err := sh.Output("go", "env", "GOOS")
 	if err != nil {
-		return err
+		return BuildInfo{}, err
 	}
 
 	goarch, err := sh.Output("go", "env", "GOARCH")
 	if err != nil {
-		return err
+		return BuildInfo{}, err
 	}
 
-	return BuildFor(ctx, goos, goarch, name)
+	return BuildForWithInfo(ctx, goos, goarch, name)
+}
+
+// BuildDefault binary and SHA256 sum using settings from system env.
+func BuildWithSHA(ctx context.Context, goos, goarch, name string) {
+	mg.CtxDeps(ctx, func() error {
+		_, err := BuildWithSHAWithInfo(ctx, goos, goarch, name)
+		return err
+	})
 }
 
 // BuildDefault binary and SHA256 sum using settings from system env
-func BuildWithSHA(ctx context.Context, goos, goarch, name string) {
-	mg.SerialCtxDeps(ctx, mg.F(BuildFor, goos, goarch, name))
-	mg.SerialCtxDeps(ctx, mg.F(SHA256Sum, path.Join(TargetDir, "bin", goos, goarch, name)))
+func BuildWithSHAWithInfo(ctx context.Context, goos, goarch, name string) (BuildInfo, error) {
+	info, err := BuildForWithInfo(ctx, goos, goarch, name)
+	if err != nil {
+		return BuildInfo{}, err
+	}
+
+	return info, SHA256Sum(ctx, info.BinPath)
 }
 
-// BuildDefault binary using settings from system env.
+// BuildFor builds binary for wanted architecture using default directory schema for output path.
 func BuildFor(ctx context.Context, goos, goarch, name string) error {
+	_, err := BuildForWithInfo(ctx, goos, goarch, name)
+	return err
+}
+
+// BuildForWithInfo builds binary for wanted architecture using default directory schema for output path
+// and returns additional build information.
+func BuildForWithInfo(ctx context.Context, goos, goarch, name string) (BuildInfo, error) {
 	cmdPath := CmdDir + name
 	binaryPath := path.Join(TargetDir, "bin", goos, goarch, name)
 	env := map[string]string{
 		"GOOS":   goos,
 		"GOARCH": goarch,
 	}
-	return GoWith(ctx, env, "build", "-o", binaryPath, cmdPath)
+
+	res := BuildInfo{BinPath: binaryPath, GOOS: goos, GOARCH: goarch}
+	return res, GoWith(ctx, env, "build", "-o", binaryPath, cmdPath)
 }
 
 // BuildForLinux builds binary for amd64 based linux systems.
@@ -102,9 +136,19 @@ func BuildForLinux(ctx context.Context, name string) {
 	BuildWithSHA(ctx, "linux", "amd64", name)
 }
 
+// BuildForLinuxWithInfo builds binary for amd64 based linux systems and returns additional build information.
+func BuildForLinuxWithInfo(ctx context.Context, name string) (BuildInfo, error) {
+	return BuildWithSHAWithInfo(ctx, "linux", "amd64", name)
+}
+
 // BuildForMac builds binary for amd64 based mac systems.
 func BuildForMac(ctx context.Context, name string) {
 	BuildWithSHA(ctx, "darwin", "amd64", name)
+}
+
+// BuildForMacWithInfo builds binary for amd64 based Mac systems and returns additional build information.
+func BuildForMacWithInfo(ctx context.Context, name string) (BuildInfo, error) {
+	return BuildWithSHAWithInfo(ctx, "darwin", "amd64", name)
 }
 
 // BuildForArmMac builds binary for arm64 based mac systems.
@@ -112,9 +156,19 @@ func BuildForArmMac(ctx context.Context, name string) {
 	BuildWithSHA(ctx, "darwin", "arm64", name)
 }
 
+// BuildForArmMacWithInfo builds binary for amd64 based Mac systems and returns additional build information.
+func BuildForArmMacWithInfo(ctx context.Context, name string) (BuildInfo, error) {
+	return BuildWithSHAWithInfo(ctx, "darwin", "arm64", name)
+}
+
 // BuildForWindows builds binary for amd64 based windows systems.
 func BuildForWindows(ctx context.Context, name string) {
 	BuildWithSHA(ctx, "windows", "amd64", name)
+}
+
+// BuildForWindowsWithInfo builds binary for amd64 based Windows systems and returns additional build information.
+func BuildForWindowsWithInfo(ctx context.Context, name string) (BuildInfo, error) {
+	return BuildWithSHAWithInfo(ctx, "windows", "amd64", name)
 }
 
 // Run executes app binary from default path.


### PR DESCRIPTION
Elikkäs tämän avulla binäärin post process hommat helpottuu kun pathi on tiedossa eikä sitä tarvitse koittaa uudestaan muodostaa käsin.