### PR TITLE
Allow target overwriting

### DIFF
--- a/cdk/target/cdk.go
+++ b/cdk/target/cdk.go
@@ -13,39 +13,55 @@ import (
 
 type CDK mg.Namespace
 
-var NpmCmd = npm.NewCmd("manifests/cdk")
-
 // Install installs npm dependencies for CDK project
-func (CDK) Install(ctx context.Context) error {
-	return NpmCmd.Install(ctx)
-}
+func (CDK) Install(ctx context.Context) error { return InstallFn.Run(ctx) }
 
 // CleanInstall performs clean install for CDK project dependencies
-func (CDK) CleanInstall(ctx context.Context) error {
-	return NpmCmd.CleanInstall(ctx)
-}
+func (CDK) CleanInstall(ctx context.Context) error { return CleanInstallFn.Run(ctx) }
 
 // Deploy runs deploy on CDK project to production environment
-func (CDK) Deploy(ctx context.Context) error {
-	return NpmCmd.Run(ctx, "deploy-all-production")
-}
+func (CDK) Deploy(ctx context.Context) error { return DeployFn.Run(ctx) }
 
 // Diff runs projen diff on CDK project
-func (CDK) Diff(ctx context.Context) error {
-	return NpmCmd.Run(ctx, "diff-all-production")
-}
+func (CDK) Diff(ctx context.Context) error { return DiffFn.Run(ctx) }
 
 // Build runs build for CDK project
-func (CDK) Build(ctx context.Context) error {
-	return NpmCmd.Run(ctx, "build")
-}
+func (CDK) Build(ctx context.Context) error { return BuildFn.Run(ctx) }
 
 // Synth runs projen synth on CDK project
-func (CDK) Synth(ctx context.Context) error {
-	return NpmCmd.Run(ctx, "synth")
-}
+func (CDK) Synth(ctx context.Context) error { return SynthFn.Run(ctx) }
 
 // Update runs package upgrades on CDK project
-func (CDK) Update(ctx context.Context) error {
-	return NpmCmd.Run(ctx, "projen", "upgrade")
-}
+func (CDK) Update(ctx context.Context) error { return UpdateFn.Run(ctx) }
+
+var NpmCmd = npm.NewCmd("manifests/cdk")
+
+var (
+	InstallFn mg.Fn = mg.F(func(ctx context.Context) error {
+		return NpmCmd.Install(ctx)
+	})
+
+	CleanInstallFn mg.Fn = mg.F(func(ctx context.Context) error {
+		return NpmCmd.CleanInstall(ctx)
+	})
+
+	DeployFn mg.Fn = mg.F(func(ctx context.Context) error {
+		return NpmCmd.Run(ctx, "deploy-all-production")
+	})
+
+	DiffFn mg.Fn = mg.F(func(ctx context.Context) error {
+		return NpmCmd.Run(ctx, "diff-all-production")
+	})
+
+	BuildFn mg.Fn = mg.F(func(ctx context.Context) error {
+		return NpmCmd.Run(ctx, "build")
+	})
+
+	SynthFn mg.Fn = mg.F(func(ctx context.Context) error {
+		return NpmCmd.Run(ctx, "synth")
+	})
+
+	UpdateFn mg.Fn = mg.F(func(ctx context.Context) error {
+		return NpmCmd.Run(ctx, "projen", "upgrade")
+	})
+)

--- a/cyclonedx/target/cyclonedx.go
+++ b/cyclonedx/target/cyclonedx.go
@@ -9,13 +9,15 @@ import (
 
 type Go mg.Namespace
 
+// SBOM generates a sbom for all binaries under target/bin
+func (Go) SBOM(ctx context.Context) error { return SBOMFn.Run(ctx) }
+
 var (
 	SbomTargets []string
 	BinRoot     = "target/bin/"
 )
 
-// SBOM generates a sbom for all binaries under target/bin
-func (Go) SBOM(ctx context.Context) error {
+var SBOMFn mg.Fn = mg.F(func(ctx context.Context) error {
 	if len(SbomTargets) == 0 {
 		targets, err := cyclonedx.FindTargets(BinRoot)
 		if err != nil {
@@ -31,4 +33,4 @@ func (Go) SBOM(ctx context.Context) error {
 
 	mg.CtxDeps(ctx, fns...)
 	return nil
-}
+})

--- a/git/target/git.go
+++ b/git/target/git.go
@@ -14,6 +14,8 @@ import (
 type Git mg.Namespace
 
 // Clean removes all untracked files from workspace
-func (Git) Clean(ctx context.Context) error {
+func (Git) Clean(ctx context.Context) error { return CleanFn.Run(ctx) }
+
+var CleanFn mg.Fn = mg.F(func(ctx context.Context) error {
 	return git.Clean(ctx, "-Xdf")
-}
+})

--- a/golang/target/go.go
+++ b/golang/target/go.go
@@ -16,6 +16,57 @@ import (
 	"github.com/magefile/mage/sh"
 )
 
+type Go mg.Namespace
+
+// Build builds binary and calculates sha sum for it
+func (Go) Build(ctx context.Context) error { return BuildFn.Run(ctx) }
+
+// CrossBuild builds binary for build matrix
+func (Go) CrossBuild(ctx context.Context) error { return CrossBuildFn.Run(ctx) }
+
+// TestBuild builds binary with race detection and coverage collections
+func (Go) TestBuild(ctx context.Context) error { return TestBuildFn.Run(ctx) }
+
+// E2eBuild builds binary with coverage collections
+func (Go) E2eBuild(ctx context.Context) error { return E2eBuildFn.Run(ctx) }
+
+// Run builds binary and executes it
+func (Go) Run(ctx context.Context) error { return RunFn.Run(ctx) }
+
+// Test runs unit and integration tests
+func (Go) Test(ctx context.Context) error { return TestFn.Run(ctx) }
+
+// UnitTest runs all unit tests
+func (Go) UnitTest(ctx context.Context) error { return UnitTestFn.Run(ctx) }
+
+// IntegrationTest runs integration tests
+func (Go) IntegrationTest(ctx context.Context) error { return IntegrationTestFn.Run(ctx) }
+
+// CoverProfile converts binary coverage into text format
+func (Go) CoverProfile(ctx context.Context) error { return CoverProfileFn.Run(ctx) }
+
+// ViewCoverage opens test coverage in browser
+func (Go) ViewCoverage(ctx context.Context) error { return ViewCoverageFn.Run(ctx) }
+
+// TestAndCover runs all tests and opens coverage in browser
+func (Go) TestAndCover(ctx context.Context) error { return TestAndCoverFn.Run(ctx) }
+
+// Tidy runs go mod tidy
+func (Go) Tidy(ctx context.Context) error { return TidyFn.Run(ctx) }
+
+// TidyAndVerify verifies that go.mod matches imports
+func (Go) TidyAndVerify(ctx context.Context) error { return TidyAndVerifyFn.Run(ctx) }
+
+// RegenIntegrationTestArtifacts regenerates the integration test artifacts
+func (Go) RegenIntegrationTestArtifacts(ctx context.Context) error {
+	return RegenIntegrationTestArtifactsFn.Run(ctx)
+}
+
+// IntegrationTestAndValidate runs the integration tests and checks that testdata artifacts are unchanged
+func (Go) IntegrationTestAndValidate(ctx context.Context) error {
+	return IntegrationTestAndValidateFn.Run(ctx)
+}
+
 var (
 	BuildTarget    = ""
 	ExtraBuildArgs = []string{}
@@ -24,110 +75,95 @@ var (
 	RunEnvs        = map[string]string{}
 )
 
-type Go mg.Namespace
-
-// Build builds binary and calculates sha sum for it
-func (Go) Build(ctx context.Context) error {
-	_, err := golang.WithSHA(golang.Build(ctx, BuildTarget, ExtraBuildArgs...))
-	return err
-}
-
-// CrossBuild builds binary for build matrix
-func (Go) CrossBuild(ctx context.Context) error {
-	_, err := golang.BuildFromMatrixWithSHA(ctx, nil, BuildMatrix, BuildTarget)
-	return err
-}
-
-// TestBuild builds binary with race detection and coverage collections
-func (Go) TestBuild(ctx context.Context) error {
-	_, err := golang.WithSHA(golang.BuildForTesting(ctx, BuildTarget, false, golang.TestBinDir))
-	return err
-}
-
-// E2eBuild builds binary with coverage collections
-func (Go) E2eBuild(ctx context.Context) error {
-	_, err := golang.WithSHA(golang.BuildForTesting(ctx, BuildTarget, true, golang.BinDir))
-	return err
-}
-
-// Run builds binary and executes it
-func (Go) Run(ctx context.Context) error {
-	info, err := golang.WithSHA(golang.Build(ctx, BuildTarget, ExtraBuildArgs...))
-	if err != nil {
+var (
+	BuildFn mg.Fn = mg.F(func(ctx context.Context) error {
+		_, err := golang.WithSHA(golang.Build(ctx, BuildTarget, ExtraBuildArgs...))
 		return err
-	}
-	return sh.RunWithV(RunEnvs, info.BinPath, RunArgs...)
-}
+	})
 
-// Test runs unit and integration tests
-func (Go) Test(ctx context.Context) {
-	mg.SerialCtxDeps(ctx, Go.UnitTest, Go.IntegrationTest)
-}
-
-// UnitTest runs all unit tests
-func (Go) UnitTest(ctx context.Context) error {
-	err := golang.UnitTest(ctx, golang.UnitTestCoverDir)
-	if err != nil {
+	CrossBuildFn mg.Fn = mg.F(func(ctx context.Context) error {
+		_, err := golang.BuildFromMatrixWithSHA(ctx, nil, BuildMatrix, BuildTarget)
 		return err
-	}
-	return golang.CreateCoverProfile(ctx, golang.UnitTestCoverProfile, golang.UnitTestCoverDir)
-}
+	})
 
-// IntegrationTest runs integration tests
-func (Go) IntegrationTest(ctx context.Context) error {
-	err := golang.RunIntegrationTests(ctx, golang.IntegrationTestPkg)
-	if err != nil {
+	TestBuildFn mg.Fn = mg.F(func(ctx context.Context) error {
+		_, err := golang.WithSHA(golang.BuildForTesting(ctx, BuildTarget, false, golang.TestBinDir))
 		return err
-	}
-	return golang.CreateCoverProfile(ctx, golang.IntegrationTestCoverProfile, golang.IntegrationTestCoverDir)
-}
+	})
 
-// CoverProfile converts binary coverage into text format
-func (Go) CoverProfile(ctx context.Context) error {
-	return golang.CreateCoverProfile(ctx, golang.CombinedCoverProfile, golang.IntegrationTestCoverDir, golang.UnitTestCoverDir)
-}
-
-// ViewCoverage opens test coverage in browser
-func (Go) ViewCoverage(ctx context.Context) error {
-	return golang.Go(ctx, "tool", "cover", "-html", golang.CombinedCoverProfile)
-}
-
-// TestAndCover runs all tests and opens coverage in browser
-func (Go) TestAndCover(ctx context.Context) {
-	mg.SerialCtxDeps(ctx, Go.UnitTest, Go.IntegrationTest, Go.CoverProfile, Go.ViewCoverage)
-}
-
-// Tidy runs go mod tidy
-func (Go) Tidy(ctx context.Context) error {
-	return golang.Tidy(ctx)
-}
-
-// TidyAndVerify verifies that go.mod matches imports
-func (Go) TidyAndVerify(ctx context.Context) error {
-	return golang.TidyAndVerify(ctx)
-}
-
-// RegenIntegrationTestArtifacts regenerates the integration test artifacts
-func (Go) RegenIntegrationTestArtifacts(ctx context.Context) {
-	os.Setenv("OVERRIDE_TEST_DATA", "true")
-	mg.SerialCtxDeps(ctx,
-		mg.F(sh.Rm, "./integrationtests/testdata"),
-		Go.IntegrationTest,
-	)
-}
-
-// IntegrationTestAndValidate runs the integration tests and checks that testdata artifacts are unchanged
-func (Go) IntegrationTestAndValidate(ctx context.Context) error {
-	mg.SerialCtxDeps(ctx, Go.RegenIntegrationTestArtifacts)
-	out, err := sh.Output("git", "status", "--porcelain", "--", "./integrationtests/testdata/")
-	if err != nil {
+	E2eBuildFn mg.Fn = mg.F(func(ctx context.Context) error {
+		_, err := golang.WithSHA(golang.BuildForTesting(ctx, BuildTarget, true, golang.BinDir))
 		return err
-	}
+	})
 
-	if len(out) > 0 {
-		fmt.Println(out)
-		return errors.New("testdata artifacts have changed")
-	}
+	RunFn mg.Fn = mg.F(func(ctx context.Context) error {
+		info, err := golang.WithSHA(golang.Build(ctx, BuildTarget, ExtraBuildArgs...))
+		if err != nil {
+			return err
+		}
+		return sh.RunWithV(RunEnvs, info.BinPath, RunArgs...)
+	})
 
-	return nil
-}
+	TestFn mg.Fn = mg.F(func(ctx context.Context) {
+		mg.SerialCtxDeps(ctx, Go.UnitTest, Go.IntegrationTest)
+	})
+
+	UnitTestFn mg.Fn = mg.F(func(ctx context.Context) error {
+		err := golang.UnitTest(ctx, golang.UnitTestCoverDir)
+		if err != nil {
+			return err
+		}
+		return golang.CreateCoverProfile(ctx, golang.UnitTestCoverProfile, golang.UnitTestCoverDir)
+	})
+
+	IntegrationTestFn mg.Fn = mg.F(func(ctx context.Context) error {
+		err := golang.RunIntegrationTests(ctx, golang.IntegrationTestPkg)
+		if err != nil {
+			return err
+		}
+		return golang.CreateCoverProfile(ctx, golang.IntegrationTestCoverProfile, golang.IntegrationTestCoverDir)
+	})
+
+	CoverProfileFn mg.Fn = mg.F(func(ctx context.Context) error {
+		return golang.CreateCoverProfile(ctx, golang.CombinedCoverProfile, golang.IntegrationTestCoverDir, golang.UnitTestCoverDir)
+	})
+
+	ViewCoverageFn mg.Fn = mg.F(func(ctx context.Context) error {
+		return golang.Go(ctx, "tool", "cover", "-html", golang.CombinedCoverProfile)
+	})
+
+	TestAndCoverFn mg.Fn = mg.F(func(ctx context.Context) {
+		mg.SerialCtxDeps(ctx, Go.UnitTest, Go.IntegrationTest, Go.CoverProfile, Go.ViewCoverage)
+	})
+
+	TidyFn mg.Fn = mg.F(func(ctx context.Context) error {
+		return golang.Tidy(ctx)
+	})
+
+	TidyAndVerifyFn mg.Fn = mg.F(func(ctx context.Context) error {
+		return golang.TidyAndVerify(ctx)
+	})
+
+	RegenIntegrationTestArtifactsFn mg.Fn = mg.F(func(ctx context.Context) {
+		os.Setenv("OVERRIDE_TEST_DATA", "true")
+		mg.SerialCtxDeps(ctx,
+			mg.F(sh.Rm, "./integrationtests/testdata"),
+			Go.IntegrationTest,
+		)
+	})
+
+	IntegrationTestAndValidateFn mg.Fn = mg.F(func(ctx context.Context) error {
+		mg.SerialCtxDeps(ctx, Go.RegenIntegrationTestArtifacts)
+		out, err := sh.Output("git", "status", "--porcelain", "--", "./integrationtests/testdata/")
+		if err != nil {
+			return err
+		}
+
+		if len(out) > 0 {
+			fmt.Println(out)
+			return errors.New("testdata artifacts have changed")
+		}
+
+		return nil
+	})
+)

--- a/golangcilint/target/lint.go
+++ b/golangcilint/target/lint.go
@@ -13,11 +13,17 @@ import (
 type Go mg.Namespace
 
 // Lint runs golangci-lint for all go files
-func (Go) Lint(ctx context.Context) error {
-	return golangcilint.Run(ctx, "run", "./...")
-}
+func (Go) Lint(ctx context.Context) error { return LintFn.Run(ctx) }
 
 // LintAndFix runs golangci-lint for all go files with --fix flag
-func (Go) LintAndFix(ctx context.Context) error {
-	return golangcilint.Run(ctx, "run", "--fix", "./...")
-}
+func (Go) LintAndFix(ctx context.Context) error { return LintAndFixFn.Run(ctx) }
+
+var (
+	LintFn mg.Fn = mg.F(func(ctx context.Context) error {
+		return golangcilint.Run(ctx, "run", "./...")
+	})
+
+	LintAndFixFn mg.Fn = mg.F(func(ctx context.Context) error {
+		return golangcilint.Run(ctx, "run", "--fix", "./...")
+	})
+)

--- a/govulncheck/target/check.go
+++ b/govulncheck/target/check.go
@@ -15,8 +15,10 @@ import (
 type Go mg.Namespace
 
 // VulnCheck runs golang.org/x/vuln/scan for all packages
-func (Go) VulnCheck(ctx context.Context) error {
+func (Go) VulnCheck(ctx context.Context) error { return VulnCheckFn.Run(ctx) }
+
+var VulnCheckFn mg.Fn = mg.F(func(ctx context.Context) error {
 	fmt.Fprintf(os.Stderr, "Warning: vuln check integration in mageutil package will be deprecated in future major release!\n")
 	fmt.Fprintf(os.Stderr, "Warning: Please migrate to use alternate solutions e.g. GitHub Dependabot Alerts for your projects.\n")
 	return govulncheck.Run(ctx, "./...")
-}
+})

--- a/lambda/target/lambda.go
+++ b/lambda/target/lambda.go
@@ -19,6 +19,8 @@ var (
 type Lambda mg.Namespace
 
 // BuildAll builds lambda bootstrap binaries and calculates sha sums for them
-func (Lambda) BuildAll(ctx context.Context) error {
+func (Lambda) BuildAll(ctx context.Context) error { return BuildAllFn.Run(ctx) }
+
+var BuildAllFn mg.Fn = mg.F(func(ctx context.Context) error {
 	return lambda.BuildAll(ctx, BuildTargets, GOARCH)
-}
+})

--- a/npm/target/npm.go
+++ b/npm/target/npm.go
@@ -13,54 +13,76 @@ import (
 
 type Npm mg.Namespace
 
-var NpmCmd = npm.NewCmd()
-
 // Audit runs npm's security audit tool
-func (Npm) Audit(ctx context.Context) error {
-	return NpmCmd.Audit(ctx)
-}
+func (Npm) Audit(ctx context.Context) error { return AuditFn.Run(ctx) }
 
 // Install installs npm dependencies
-func (Npm) Install(ctx context.Context) error {
-	return NpmCmd.Install(ctx)
-}
+func (Npm) Install(ctx context.Context) error { return InstallFn.Run(ctx) }
 
 // CleanInstall does clean install on npm dependencies
-func (Npm) CleanInstall(ctx context.Context) error {
-	return NpmCmd.CleanInstall(ctx)
-}
+func (Npm) CleanInstall(ctx context.Context) error { return CleanInstallFn.Run(ctx) }
 
 // Update updates npm dependencies
-func (Npm) Update(ctx context.Context) error {
-	return NpmCmd.Update(ctx)
-}
+func (Npm) Update(ctx context.Context) error { return UpdateFn.Run(ctx) }
 
 // CleanBuild executes clean-install before build script
-func (Npm) CleanBuild(ctx context.Context) {
-	mg.SerialCtxDeps(ctx, Npm.CleanInstall, Npm.Build)
-}
+func (Npm) CleanBuild(ctx context.Context) error { return CleanBuildFn.Run(ctx) }
 
 // Build executes build script
-func (Npm) Build(ctx context.Context) error {
-	return NpmCmd.Run(ctx, "build")
-}
+func (Npm) Build(ctx context.Context) error { return BuildFn.Run(ctx) }
 
 // Start executes start script
-func (Npm) Start(ctx context.Context) error {
-	return NpmCmd.Run(ctx, "start")
-}
+func (Npm) Start(ctx context.Context) error { return StartFn.Run(ctx) }
 
 // TypeCheck executes typecheck script
-func (Npm) TypeCheck(ctx context.Context) error {
-	return NpmCmd.Run(ctx, "typecheck")
-}
+func (Npm) TypeCheck(ctx context.Context) error { return TypeCheckFn.Run(ctx) }
 
 // Lint executes lint script
-func (Npm) Lint(ctx context.Context) error {
-	return NpmCmd.Run(ctx, "lint")
-}
+func (Npm) Lint(ctx context.Context) error { return LintFn.Run(ctx) }
 
 // Lint executes test script
-func (Npm) Test(ctx context.Context) error {
-	return NpmCmd.Run(ctx, "test")
-}
+func (Npm) Test(ctx context.Context) error { return TestFn.Run(ctx) }
+
+var NpmCmd = npm.NewCmd()
+
+var (
+	AuditFn mg.Fn = mg.F(func(ctx context.Context) error {
+		return NpmCmd.Audit(ctx)
+	})
+
+	InstallFn mg.Fn = mg.F(func(ctx context.Context) error {
+		return NpmCmd.Install(ctx)
+	})
+
+	CleanInstallFn mg.Fn = mg.F(func(ctx context.Context) error {
+		return NpmCmd.CleanInstall(ctx)
+	})
+
+	UpdateFn mg.Fn = mg.F(func(ctx context.Context) error {
+		return NpmCmd.Update(ctx)
+	})
+
+	CleanBuildFn mg.Fn = mg.F(func(ctx context.Context) {
+		mg.SerialCtxDeps(ctx, Npm.CleanInstall, Npm.Build)
+	})
+
+	BuildFn mg.Fn = mg.F(func(ctx context.Context) error {
+		return NpmCmd.Run(ctx, "build")
+	})
+
+	StartFn mg.Fn = mg.F(func(ctx context.Context) error {
+		return NpmCmd.Run(ctx, "start")
+	})
+
+	TypeCheckFn mg.Fn = mg.F(func(ctx context.Context) error {
+		return NpmCmd.Run(ctx, "typecheck")
+	})
+
+	LintFn mg.Fn = mg.F(func(ctx context.Context) error {
+		return NpmCmd.Run(ctx, "lint")
+	})
+
+	TestFn mg.Fn = mg.F(func(ctx context.Context) error {
+		return NpmCmd.Run(ctx, "test")
+	})
+)

--- a/swaggo/target/swaggo.go
+++ b/swaggo/target/swaggo.go
@@ -14,6 +14,15 @@ import (
 
 type Docs mg.Namespace
 
+// OpenAPI generates OpenAPI files using swaggo
+func (Docs) OpenAPI(ctx context.Context) error { return OpenAPIFn.Run(ctx) }
+
+// OpenAPIAndVerify generates OpenAPI files using swaggo and verifies output against the version control
+func (Docs) OpenAPIAndVerify(ctx context.Context) error { return OpenAPIAndVerifyFn.Run(ctx) }
+
+// OpenAPIAndLint generates OpenAPI files using swaggo and lints output against OpenAPI specification ruleset
+func (Docs) OpenAPIAndLint(ctx context.Context) error { return OpenAPIAndLintFn.Run(ctx) }
+
 var (
 	SearchDir    = ""
 	ApiFile      = ""
@@ -22,17 +31,16 @@ var (
 	LintSeverity = "error"
 )
 
-// OpenAPI generates OpenAPI files using swaggo
-func (Docs) OpenAPI(ctx context.Context) error {
-	return swaggo.GenerateDocs(ctx, SearchDir, ApiFile, OutputDir)
-}
+var (
+	OpenAPIFn mg.Fn = mg.F(func(ctx context.Context) error {
+		return swaggo.GenerateDocs(ctx, SearchDir, ApiFile, OutputDir)
+	})
 
-// OpenAPIAndVerify generates OpenAPI files using swaggo and verifies output against the version control
-func (Docs) OpenAPIAndVerify(ctx context.Context) error {
-	return swaggo.GenerateDocsAndVerify(ctx, SearchDir, ApiFile, OutputDir)
-}
+	OpenAPIAndVerifyFn mg.Fn = mg.F(func(ctx context.Context) error {
+		return swaggo.GenerateDocsAndVerify(ctx, SearchDir, ApiFile, OutputDir)
+	})
 
-// OpenAPIAndLint generates OpenAPI files using swaggo and lints output against OpenAPI specification ruleset
-func (Docs) OpenAPIAndLint(ctx context.Context) {
-	mg.SerialCtxDeps(ctx, Docs.OpenAPI, mg.F(swaggo.LintDocs, LintSeverity, LintRuleset, OutputDir))
-}
+	OpenAPIAndLintFn mg.Fn = mg.F(func(ctx context.Context) {
+		mg.SerialCtxDeps(ctx, Docs.OpenAPI, mg.F(swaggo.LintDocs, LintSeverity, LintRuleset, OutputDir))
+	})
+)

--- a/util.go
+++ b/util.go
@@ -1,0 +1,63 @@
+package mageutil
+
+import (
+	"context"
+	"strings"
+
+	"github.com/magefile/mage/mg"
+)
+
+type (
+	SerialFns   []mg.Fn
+	ParallelFns []mg.Fn
+)
+
+func (s SerialFns) ID() string {
+	ids := make([]string, 0, len(s))
+	for _, f := range s {
+		ids = append(ids, f.ID())
+	}
+	return strings.Join(ids, ":")
+}
+
+func (s SerialFns) Name() string {
+	ids := make([]string, 0, len(s))
+	for _, f := range s {
+		ids = append(ids, f.Name())
+	}
+	return strings.Join(ids, ":")
+}
+
+func (s SerialFns) Run(ctx context.Context) error {
+	fns := make([]interface{}, 0, len(s))
+	for _, f := range s {
+		fns = append(fns, f)
+	}
+	mg.SerialCtxDeps(ctx, fns...)
+	return nil
+}
+
+func (p ParallelFns) ID() string {
+	ids := make([]string, 0, len(p))
+	for _, f := range p {
+		ids = append(ids, f.ID())
+	}
+	return strings.Join(ids, ":")
+}
+
+func (p ParallelFns) Name() string {
+	ids := make([]string, 0, len(p))
+	for _, f := range p {
+		ids = append(ids, f.Name())
+	}
+	return strings.Join(ids, ":")
+}
+
+func (p ParallelFns) Run(ctx context.Context) error {
+	fns := make([]interface{}, 0, len(p))
+	for _, f := range p {
+		fns = append(fns, f)
+	}
+	mg.CtxDeps(ctx, fns...)
+	return nil
+}

--- a/yamlfmt/target/yaml.go
+++ b/yamlfmt/target/yaml.go
@@ -12,16 +12,22 @@ import (
 	"github.com/magefile/mage/mg"
 )
 
-var YamlFiles = []string{}
-
 type Yaml mg.Namespace
 
 // Fmt formats yaml files
-func (Yaml) Fmt(ctx context.Context) error {
-	return yamlfmt.Fmt(ctx, YamlFiles...)
-}
+func (Yaml) Fmt(ctx context.Context) error { return FmtFn.Run(ctx) }
 
 // Lint lints yaml files
-func (Yaml) Lint(ctx context.Context) error {
-	return yamlfmt.Lint(ctx, YamlFiles...)
-}
+func (Yaml) Lint(ctx context.Context) error { return LintFn.Run(ctx) }
+
+var YamlFiles = []string{}
+
+var (
+	FmtFn mg.Fn = mg.F(func(ctx context.Context) error {
+		return yamlfmt.Fmt(ctx, YamlFiles...)
+	})
+
+	LintFn mg.Fn = mg.F(func(ctx context.Context) error {
+		return yamlfmt.Lint(ctx, YamlFiles...)
+	})
+)


### PR DESCRIPTION
## What?

Allow overwriting and adding post/pre hooks into targets.

## Why?

Currently custom build/test/etc  target is added as new target while the original remains. In most cases the custom target should replace the original one instead of creating another. This is confusing and error prone to end user which can see targets that shouldn't be use. 

## How?
```go
func init() {
	// Target overwriting
	golang.BuildFn = mg.F(customBuild)

	// Add Pre and Post hooks
	cdx.SBOMFn = mageutil.SerialFns{
		mg.F(preSBOM),
		cdx.SBOMFn,
		mg.F(postSBOM),
	}
}

func preSBOM(context.Context)  { fmt.Println("Running pre hook") }
func postSBOM(context.Context) { fmt.Println("Running post hook") }
func customBuild(ctx context.Context) error {
	fmt.Println("Running custom build")
	info, err := goutil.WithSHA(goutil.Build(ctx, golang.BuildTarget))
	if err != nil {
		return err
	}

	fmt.Printf("%+v\n", info)
	return nil
}
```
