### PR TITLE
Configurable project authors for Docker image

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -105,7 +105,7 @@ func DefaultLabels(imageName, url, desc string) map[string]string {
 		OCILabelCreated:     time.Now().String(),
 		OCILabelSource:      url,
 		OCILabelLicenses:    "",
-		OCILabelAuthors:     "SoSe/SRE",
+		OCILabelAuthors:     "DiSe/SRE",
 		OCILabelVendor:      "Elisa",
 		OCILabelRevision:    "",
 	}

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -27,6 +27,7 @@ const (
 const (
 	DefaultPlatform   = "linux/amd64"
 	DefaultDockerfile = "Dockerfile"
+	DefaultAuthors    = "DiSe/SRE"
 	DefaultBuildCtx   = "."
 	DefaultExtraCtx   = "./target/bin/linux/amd64/"
 )
@@ -48,14 +49,14 @@ func PushAllTags(ctx context.Context, imageName string) error {
 
 // BuildDefault builds image with sane defaults.
 func BuildDefault(ctx context.Context, imageName, url string) error {
-	return BuildDefaultWithDockerfile(ctx, imageName, url, DefaultDockerfile)
+	return BuildDefaultWithDockerfile(ctx, imageName, url, DefaultAuthors, DefaultDockerfile)
 }
 
 // BuildDefaultWithDockerfile builds image from custom Dockerfile location
-func BuildDefaultWithDockerfile(ctx context.Context, imageName, url string, dockerfile string) error {
+func BuildDefaultWithDockerfile(ctx context.Context, imageName, url, authors string, dockerfile string) error {
 	fullTags := Tags(imageName)
 	extraCtx := map[string]string{"bin": DefaultExtraCtx}
-	labels := DefaultLabels(imageName, url, "")
+	labels := DefaultLabels(imageName, url, authors, "")
 	return Build(ctx, DefaultPlatform, dockerfile, DefaultBuildCtx, fullTags, extraCtx, labels)
 }
 
@@ -95,8 +96,8 @@ func Tags(imageName string, tags ...string) []string {
 	return fullTags
 }
 
-// DefaultLabels provides labels for Elisa SoSe/SRE organization.
-func DefaultLabels(imageName, url, desc string) map[string]string {
+// DefaultLabels provides labels for Elisa organization.
+func DefaultLabels(imageName, url, desc, authors string) map[string]string {
 	return map[string]string{
 		OCILabelTitle:       path.Base(imageName),
 		OCILabelURL:         url,
@@ -105,7 +106,7 @@ func DefaultLabels(imageName, url, desc string) map[string]string {
 		OCILabelCreated:     time.Now().String(),
 		OCILabelSource:      url,
 		OCILabelLicenses:    "",
-		OCILabelAuthors:     "DiSe/SRE",
+		OCILabelAuthors:     authors,
 		OCILabelVendor:      "Elisa",
 		OCILabelRevision:    "",
 	}

--- a/docker/target/docker.go
+++ b/docker/target/docker.go
@@ -16,9 +16,10 @@ import (
 type Docker mg.Namespace
 
 var (
-	ImageName  = ""
-	ProjectUrl = "" // Used for OCI label.
-	Dockerfile = docker.DefaultDockerfile
+	ImageName      = ""
+	ProjectUrl     = "" // Used for OCI label.
+	ProjectAuthors = docker.DefaultAuthors
+	Dockerfile     = docker.DefaultDockerfile
 )
 
 // Push pushes all tags for image
@@ -28,7 +29,7 @@ func (Docker) Push(ctx context.Context) error {
 
 // Build builds docker image
 func (Docker) Build(ctx context.Context) error {
-	return docker.BuildDefaultWithDockerfile(ctx, ImageName, ProjectUrl, Dockerfile)
+	return docker.BuildDefaultWithDockerfile(ctx, ImageName, ProjectUrl, ProjectAuthors, Dockerfile)
 }
 
 // Up start containers in daemon mode

--- a/godemo/api/api.go
+++ b/godemo/api/api.go
@@ -13,7 +13,7 @@ import (
 // @description Demo service
 // @termsOfService http://swagger.io/terms/
 
-// @contact.name Software Services / SRE Team
+// @contact.name Digital Services / SRE Team
 // @contact.url http://www.elisa.fi
 // @contact.email devops@elisa.fi
 

--- a/godemo/docs/docs.go
+++ b/godemo/docs/docs.go
@@ -11,7 +11,7 @@ const docTemplate = `{
         "title": "{{.Title}}",
         "termsOfService": "http://swagger.io/terms/",
         "contact": {
-            "name": "Software Services / SRE Team",
+            "name": "Digital Services / SRE Team",
             "url": "http://www.elisa.fi",
             "email": "devops@elisa.fi"
         },

--- a/godemo/docs/swagger.json
+++ b/godemo/docs/swagger.json
@@ -5,7 +5,7 @@
         "title": "Demo",
         "termsOfService": "http://swagger.io/terms/",
         "contact": {
-            "name": "Software Services / SRE Team",
+            "name": "Digital Services / SRE Team",
             "url": "http://www.elisa.fi",
             "email": "devops@elisa.fi"
         },

--- a/godemo/docs/swagger.yaml
+++ b/godemo/docs/swagger.yaml
@@ -8,7 +8,7 @@ definitions:
 info:
   contact:
     email: devops@elisa.fi
-    name: Software Services / SRE Team
+    name: Digital Services / SRE Team
     url: http://www.elisa.fi
   description: Demo service
   license:

--- a/golang/target/go.go
+++ b/golang/target/go.go
@@ -88,7 +88,7 @@ func (Go) ViewCoverage(ctx context.Context) error {
 	return golang.Go(ctx, "tool", "cover", "-html", golang.CombinedCoverProfile)
 }
 
-// TestAndCover run sall tests and opens coverage in browser
+// TestAndCover runs all tests and opens coverage in browser
 func (Go) TestAndCover(ctx context.Context) {
 	mg.SerialCtxDeps(ctx, Go.UnitTest, Go.IntegrationTest, Go.CoverProfile, Go.ViewCoverage)
 }


### PR DESCRIPTION
The cross team usage is a bit mess due to hard-coded authors label within Docker images. Let's make it configurable.