### PR TITLE
fix to close correct file in golang sha256

### DIFF
--- a/golang/build.go
+++ b/golang/build.go
@@ -136,7 +136,7 @@ func SHA256Sum(input, output string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer sumFile.Close()
 
 	_, err = fmt.Fprintf(sumFile, "%s *%s\n", hexSum, input)
 	if err != nil {


### PR DESCRIPTION
Noticed duplicate `f.Close()` call, and sumFile seems to never be closed